### PR TITLE
Removed test for deprecated function

### DIFF
--- a/tests/test_image_property_helpers.py
+++ b/tests/test_image_property_helpers.py
@@ -6,7 +6,6 @@ from cleanvision.issue_managers import IssueType
 from cleanvision.issue_managers.image_property import (
     BrightnessProperty,
     calculate_brightness,
-    get_image_mode,
 )
 
 
@@ -36,9 +35,6 @@ def test_calculate_brightness(rgb, expected_brightness):
     ],
     ids=["white", "black", "grayscale", "rgb"],
 )
-def test_get_image_mode(image, expected_mode):
-    mode = get_image_mode(image)
-    assert mode == expected_mode
 
 
 class TestBrightnessHelper:


### PR DESCRIPTION
Pytest CI is not passing due to recent PR deprecating unused functionality (that is still being tested). Removed deprecated function from test.