### PR TITLE
Remove .JPEG & .PNG from extension list as .jpeg & .png are already present.

### DIFF
--- a/src/cleanvision/utils/utils.py
+++ b/src/cleanvision/utils/utils.py
@@ -21,8 +21,6 @@ TYPES: List[str] = [
     "*.jp2",
     "*.TIFF",
     "*.WebP",
-    "*.PNG",
-    "*.JPEG",
     "*.png",
 ]  # filetypes supported by PIL
 


### PR DESCRIPTION
**BUG**
When a image folder has .jpeg or .png extension images. Imagelab loads that image twice as shown below,

![image](https://user-images.githubusercontent.com/71626493/228607680-7e7afa44-4fc1-4cf8-9d65-688c0f2ad480.png)


Its happening because in  `src/cleanvision/utils/utils.py` the extension lists have both '.JPEG' and '.jpeg', same for .png as well.

![image](https://user-images.githubusercontent.com/71626493/228605998-95164701-1956-451c-9a12-95e8459baecd.png)


When loaded in the downstream code (by looping the extension list) using glob module to load the images, if a image has '.JPEG' extension, it load once for the '.JPEG' and once again for '.jpeg' because glob module treats both '.JPEG' and '.jpeg' as same image i.e, it doesn't matters if the extension is all caps or not.

**Solution**
Just keep '.jpeg' and '.png' in the list. It will handle even if the extension of the image is in all caps.
