### PR TITLE
add missing modules to docs index in sidebar

### DIFF
--- a/docs/source/cleanvision/issue_managers/index.rst
+++ b/docs/source/cleanvision/issue_managers/index.rst
@@ -1,0 +1,14 @@
+Issue Managers
+==============
+
+.. automodule:: cleanvision.issue_managers
+   :autosummary:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+    duplicate_issue_manager
+    image_property
+    image_property_issue_manager

--- a/docs/source/cleanvision/utils/index.rst
+++ b/docs/source/cleanvision/utils/index.rst
@@ -1,0 +1,14 @@
+Utils
+=====
+
+.. automodule:: cleanvision.utils
+   :autosummary:
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+.. toctree::
+    base_issue_manager
+    utils
+    viz_manager

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,9 +2,9 @@
 #
 # For the full list of built-in configuration values, see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
+import datetime
 import os
 import sys
-import datetime
 
 sys.path.insert(0, os.path.abspath("../../src/"))
 # -- Project information -----------------------------------------------------
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath("../../src/"))
 
 project = "cleanvision"
 copyright = f"{datetime.datetime.now().year}, Cleanlab Inc."
-author = "Cleanlab"
+author = "Cleanlab Inc."
 release = "2023"
 
 # -- General configuration ---------------------------------------------------
@@ -33,7 +33,11 @@ extensions = [
 ]
 
 templates_path = ["_templates"]
+
 exclude_patterns = ["cleanvision/issue_managers/*", "cleanvision/utils/*"]
+
+exclude_patterns = [
+]
 
 # --------- Autodoc configuration --------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,8 +36,7 @@ templates_path = ["_templates"]
 
 exclude_patterns = ["cleanvision/issue_managers/*", "cleanvision/utils/*"]
 
-exclude_patterns = [
-]
+exclude_patterns = []
 
 # --------- Autodoc configuration --------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,8 +34,6 @@ extensions = [
 
 templates_path = ["_templates"]
 
-exclude_patterns = ["cleanvision/issue_managers/*", "cleanvision/utils/*"]
-
 exclude_patterns = []
 
 # --------- Autodoc configuration --------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,13 +77,13 @@ More on how to get started with CleanVision:
 
 .. toctree::
    :hidden:
-   :maxdepth: 5
+   :maxdepth: 3
    :caption: API Reference
    :name: _api_reference
 
    cleanvision/imagelab
-   cleanvision/issue_managers
-   cleanvision/utils
+   cleanvision/issue_managers/index
+   cleanvision/utils/index
 
 .. toctree::
    :caption: Guides
@@ -98,7 +98,6 @@ More on how to get started with CleanVision:
    :caption: Links
    :hidden:
 
+   Website <https://cleanlab.ai/>
    GitHub <https://github.com/cleanlab/cleanvision.git>
    PyPI <https://pypi.org/project/cleanvision/>
-   Website <https://cleanlab.ai/>
-   Slack <https://cleanlab.ai/slack>

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -82,6 +82,8 @@ More on how to get started with CleanVision:
    :name: _api_reference
 
    cleanvision/imagelab
+   cleanvision/issue_managers
+   cleanvision/utils
 
 .. toctree::
    :caption: Guides
@@ -96,6 +98,7 @@ More on how to get started with CleanVision:
    :caption: Links
    :hidden:
 
-   Website <https://cleanlab.ai/>
    GitHub <https://github.com/cleanlab/cleanvision.git>
    PyPI <https://pypi.org/project/cleanvision/>
+   Website <https://cleanlab.ai/>
+   Slack <https://cleanlab.ai/slack>


### PR DESCRIPTION
not sure this is the best way to add these as drop-downs. Ideally in our sidebar, they should look something like these modules from the cleanlab repo:

<img width="305" alt="Screen Shot 2023-04-07 at 1 54 36 AM" src="https://user-images.githubusercontent.com/1390638/230577704-c3d143ea-3afd-4c0e-a202-0beeb3e70d20.png">

Preview:
https://cleanvision.readthedocs.io/en/jwmueller-docsmodules/
