### PR TITLE
allow cleanvision.__version__ to work

### DIFF
--- a/src/cleanvision/__init__.py
+++ b/src/cleanvision/__init__.py
@@ -1,5 +1,6 @@
-try:  # not supported on Python 3.7
+try:
     import importlib.metadata
+
     __version__ = importlib.metadata.version("cleanvision")
 except Exception:
     pass

--- a/src/cleanvision/__init__.py
+++ b/src/cleanvision/__init__.py
@@ -1,3 +1,5 @@
-import importlib.metadata
-
-__version__ = importlib.metadata.version("cleanvision")
+try:  # not supported on Python 3.7
+    import importlib.metadata
+    __version__ = importlib.metadata.version("cleanvision")
+except Exception:
+    pass

--- a/src/cleanvision/__init__.py
+++ b/src/cleanvision/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("cleanvision")

--- a/src/cleanvision/__init__.py
+++ b/src/cleanvision/__init__.py
@@ -1,4 +1,4 @@
-try:
+try:  # import only works for python>=3.8
     import importlib.metadata
 
     __version__ = importlib.metadata.version("cleanvision")


### PR DESCRIPTION
Closes https://github.com/cleanlab/cleanvision/issues/159

Not sure this is the optimal way to do it, so feel free to suggest alternative. I just followed the tips from here:
https://stackoverflow.com/questions/67085041/how-to-specify-version-in-only-one-place-when-using-pyproject-toml