### PR TITLE
pre-commit hook for clearing notebooks output and metadata

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,8 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-  - repo: local
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
     hooks:
-      - id: jupyter-nb-clear-output
-        name: jupyter-nb-clear-output
-        files: \.ipynb$
-        stages: [commit]
-        language: system
-        entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace
+      - id: nbstripout
+        description: Clears output and some metadata from notebooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,11 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
+  - repo: local
+    hooks:
+      - id: jupyter-nb-clear-output
+        name: jupyter-nb-clear-output
+        files: \.ipynb$
+        stages: [commit]
+        language: system
+        entry: jupyter nbconvert --ClearOutputPreprocessor.enabled=True --ClearMetadataPreprocessor.enabled=True --inplace


### PR DESCRIPTION
Fixes #150 

Added a new hook for clearing output and metadata for Jupyter notebooks present.

Before: 
<img width="1181" alt="Screenshot 2023-04-17 at 4 43 55 PM" src="https://user-images.githubusercontent.com/34245555/232469718-25a0ceb4-7d7f-4f64-bb9a-1ef952a0231f.png">

After applying pre-commit hook: 
<img width="1181" alt="Screenshot 2023-04-17 at 4 48 44 PM" src="https://user-images.githubusercontent.com/34245555/232470064-61c100ff-412d-4394-a850-98be11203641.png">
