### PR TITLE
Added worfklow for automatic release

### DIFF
--- a/.github/scripts/get_version.py
+++ b/.github/scripts/get_version.py
@@ -1,0 +1,4 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version("cleanvision")
+print(__version__)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  release:
+    types: [ published ]
 
 jobs:
   test:
@@ -20,12 +22,6 @@ jobs:
         run: pip install build
       - name: Build distributions
         run: python -m build
-      - name: Publish package to Test PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
       - name: Publish package to PyPI
         if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Build and publish distribution
 
+# This workflow will be triggered whenever the CI workflow is triggered in main branch is completed or a release is published
 on:
   workflow_run:
     workflows: [ "CI" ]
@@ -24,13 +25,15 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
+        # This condition ensures the CI workflow in main branch was successful and this is indeed a release published action
+        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success' && github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
   publish:
     needs: [ publish-test ]
+    # This condition ensures publish-test succeeded before running this job
     if: needs.publish-test.result == 'success'
     runs-on: "ubuntu-latest"
     steps:
@@ -45,13 +48,15 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
+        # This condition ensures the CI workflow in main branch was successful and this is indeed a release published action
+        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'  && github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
   bump-version:
     runs-on: "ubuntu-latest"
     needs: [publish]
+    # This condition ensures publish succeeded before running this job
     if: needs.publish.result == 'success'
     steps:
       - name: Checkout source

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,12 @@ jobs:
         run: pip install build
       - name: Build distributions
         run: python -m build
+      - name: Publish package to Test PyPI
+        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
       - name: Publish package to PyPI
         if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
+        if: github.repository == 'cleanlab/cleanvision'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -41,7 +41,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
+        if: github.repository == 'cleanlab/cleanvision'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,17 @@
 name: Build distribution
 
 on:
-  push:
+  workflow_run:
+    workflows: [ "CI" ]
     branches: [ main ]
-  pull_request:
+    types:
+      - completed
   release:
     types: [ published ]
 
 jobs:
-  test:
+  publish:
     runs-on: "ubuntu-latest"
-
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -23,7 +24,8 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
+        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Build distribution
 
 on:
+  # todo: remove this push condition once tested on testpypi
+  push:
+    branches: : [ main ]
   workflow_run:
     workflows: [ "CI" ]
     branches: [ main ]
@@ -29,3 +32,34 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
+
+  bump-version:
+    runs-on: "ubuntu-latest"
+    needs: [publish]
+    if: needs.b.result == 'success'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e .
+          pip install --upgrade bump2version
+      - name: Set current version
+        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
+      - name: Bump version
+        run: bump2version --current-version "${{ env.CURRENT_VERSION }}" patch pyproject.toml
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: pyproject.toml
+          branch: autobump
+          commit_message: Bump patch version
+
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Build and publish distribution
 
 on:
-  push:
-    branches: [test-publish-testpypi]
   workflow_run:
     workflows: [ "CI" ]
     branches: [ main ]
@@ -21,18 +19,8 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      - name: Install dependencies
-        run: |
-          pip install -U pip
-          pip install build
-          pip install -e .
-          pip install --upgrade bump2version
-      - name: Get sha
-        run: echo ${{ github.sha }}
-      - name: Set current version
-        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
-      - name: Bump version
-        run: sed -i "s/${{ env.CURRENT_VERSION }}/${{ env.CURRENT_VERSION }}.${{ github.sha }}/g" pyproject.toml
+      - name: Install build dependencies
+        run: pip install build
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
@@ -41,53 +29,51 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-#  publish:
-#    needs: [ publish-test ]
-#    if: needs.publish-test.result == 'success'
-#    runs-on: "ubuntu-latest"
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v3
-#      - name: Set up Python 3.11
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.11
-#      - name: Install build dependencies
-#        run: pip install build
-#      - name: Build distributions
-#        run: python -m build
-#      - name: Publish package to PyPI
-#        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
-#        uses: pypa/gh-action-pypi-publish@release/v1
-#        with:
-#          password: ${{ secrets.PYPI_API_TOKEN }}
-#  bump-version:
-#    runs-on: "ubuntu-latest"
-#    needs: [publish]
-#    if: needs.publish.result == 'success'
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v3
-#        with:
-#          ref: ${{ github.head_ref }}
-#      - name: Set up Python 3.11
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: 3.11
-#      - name: Install dependencies
-#        run: |
-#          pip install -U pip
-#          pip install -e .
-#          pip install --upgrade bump2version
-#      - name: Set current version
-#        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
-#      - name: Bump version
-#        run: bump2version --current-version "${{ env.CURRENT_VERSION }}" patch pyproject.toml
-#      - name: Commit and push
-#        uses: stefanzweifel/git-auto-commit-action@v4
-#        with:
-#          file_pattern: pyproject.toml
-#          branch: autobump
-#          commit_message: Bump patch version
-#
-#
+  publish:
+    needs: [ publish-test ]
+    if: needs.publish-test.result == 'success'
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install build dependencies
+        run: pip install build
+      - name: Build distributions
+        run: python -m build
+      - name: Publish package to PyPI
+        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+  bump-version:
+    runs-on: "ubuntu-latest"
+    needs: [publish]
+    if: needs.publish.result == 'success'
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e .
+          pip install --upgrade bump2version
+      - name: Set current version
+        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
+      - name: Bump version
+        run: bump2version --current-version "${{ env.CURRENT_VERSION }}" patch pyproject.toml
+      - name: Commit and push
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          file_pattern: pyproject.toml
+          branch: main
+          commit_message: Bump patch version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build distribution
+name: Build and publish distribution
 
 on:
   # todo: remove this push condition once tested on testpypi
@@ -13,7 +13,7 @@ on:
     types: [ published ]
 
 jobs:
-  publish:
+  publish-test:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout source
@@ -32,11 +32,30 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-
+  publish:
+    needs: [ publish-test ]
+    if: needs.publish-test.result == 'success'
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install build dependencies
+        run: pip install build
+      - name: Build distributions
+        run: python -m build
+      - name: Publish package to PyPI
+        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
   bump-version:
     runs-on: "ubuntu-latest"
     needs: [publish]
-    if: needs.b.result == 'success'
+    if: needs.publish.result == 'success'
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Build and publish distribution
 
 on:
-  # todo: remove this push condition once tested on testpypi
-  push:
-    branches: [ main ]
   workflow_run:
     workflows: [ "CI" ]
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Build distribution
 on:
   # todo: remove this push condition once tested on testpypi
   push:
-    branches: : [ main ]
+    branches: [ main ]
   workflow_run:
     workflows: [ "CI" ]
     branches: [ main ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Build distribution
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+      - name: Install build dependencies
+        run: pip install build
+      - name: Build distributions
+        run: python -m build
+      - name: Publish package to PyPI
+        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Build and publish distribution
 
 on:
+  push:
+    branches: [test-publish-testpypi]
   workflow_run:
     workflows: [ "CI" ]
     branches: [ main ]
@@ -19,8 +21,18 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.11
-      - name: Install build dependencies
-        run: pip install build
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install build
+          pip install -e .
+          pip install --upgrade bump2version
+      - name: Get sha
+        run: echo ${{ github.sha }}
+      - name: Set current version
+        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
+      - name: Bump version
+        run: sed -i "s/${{ env.CURRENT_VERSION }}/${{ env.CURRENT_VERSION }}.${{ github.sha }}/g" pyproject.toml
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
@@ -29,53 +41,53 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/
-  publish:
-    needs: [ publish-test ]
-    if: needs.publish-test.result == 'success'
-    runs-on: "ubuntu-latest"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - name: Install build dependencies
-        run: pip install build
-      - name: Build distributions
-        run: python -m build
-      - name: Publish package to PyPI
-        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-  bump-version:
-    runs-on: "ubuntu-latest"
-    needs: [publish]
-    if: needs.publish.result == 'success'
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - name: Install dependencies
-        run: |
-          pip install -U pip
-          pip install -e .
-          pip install --upgrade bump2version
-      - name: Set current version
-        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
-      - name: Bump version
-        run: bump2version --current-version "${{ env.CURRENT_VERSION }}" patch pyproject.toml
-      - name: Commit and push
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          file_pattern: pyproject.toml
-          branch: autobump
-          commit_message: Bump patch version
-
-
+#  publish:
+#    needs: [ publish-test ]
+#    if: needs.publish-test.result == 'success'
+#    runs-on: "ubuntu-latest"
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v3
+#      - name: Set up Python 3.11
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.11
+#      - name: Install build dependencies
+#        run: pip install build
+#      - name: Build distributions
+#        run: python -m build
+#      - name: Publish package to PyPI
+#        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'
+#        uses: pypa/gh-action-pypi-publish@release/v1
+#        with:
+#          password: ${{ secrets.PYPI_API_TOKEN }}
+#  bump-version:
+#    runs-on: "ubuntu-latest"
+#    needs: [publish]
+#    if: needs.publish.result == 'success'
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v3
+#        with:
+#          ref: ${{ github.head_ref }}
+#      - name: Set up Python 3.11
+#        uses: actions/setup-python@v4
+#        with:
+#          python-version: 3.11
+#      - name: Install dependencies
+#        run: |
+#          pip install -U pip
+#          pip install -e .
+#          pip install --upgrade bump2version
+#      - name: Set current version
+#        run: echo "CURRENT_VERSION=$(python .github/scripts/get_version.py)" >> "$GITHUB_ENV"
+#      - name: Bump version
+#        run: bump2version --current-version "${{ env.CURRENT_VERSION }}" patch pyproject.toml
+#      - name: Commit and push
+#        uses: stefanzweifel/git-auto-commit-action@v4
+#        with:
+#          file_pattern: pyproject.toml
+#          branch: autobump
+#          commit_message: Bump patch version
+#
+#

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,6 @@
 name: Build and publish distribution
 
-# This workflow will be triggered whenever the CI workflow is triggered in main branch is completed or a release is published
 on:
-  workflow_run:
-    workflows: [ "CI" ]
-    branches: [ main ]
-    types:
-      - completed
   release:
     types: [ published ]
 
@@ -25,8 +19,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        # This condition ensures the CI workflow in main branch was successful and this is indeed a release published action
-        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success' && github.event_name == 'release' && github.event.action == 'published'
+        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
@@ -48,8 +41,7 @@ jobs:
       - name: Build distributions
         run: python -m build
       - name: Publish package to PyPI
-        # This condition ensures the CI workflow in main branch was successful and this is indeed a release published action
-        if: github.repository == 'cleanlab/cleanvision' && github.event.workflow_run.conclusion == 'success'  && github.event_name == 'release' && github.event.action == 'published'
+        if: github.repository == 'cleanlab/cleanvision' && github.event_name == 'release' && github.event.action == 'published'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -110,9 +110,6 @@ endings match the project style.
 ## Merging PRs to the codebase
 
 The docs for this repo are hosted by readthedocs.io and can be found [here](https://cleanvision.readthedocs.io/en/latest/).
-Currently, merged PRs *will not* update the docs -- you **need** to do this manually after merging a PR.
-To update docs, go to the [readthedocs project page](https://readthedocs.org/projects/cleanvision/) and `build` latest version.
-If you want to see how a specific branch output looks, activate the branch in `version` tab and then `build` that branch.
 
 
 ## Publishing Release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -109,7 +109,15 @@ endings match the project style.
 
 ## Merging PRs to the codebase
 
-The docs for this repo are hosted by readthedocs.io and can be found [here](https://cleanvision.readthedocs.io/en/latest/). 
+The docs for this repo are hosted by readthedocs.io and can be found [here](https://cleanvision.readthedocs.io/en/latest/).
 Currently, merged PRs *will not* update the docs -- you **need** to do this manually after merging a PR.
 To update docs, go to the [readthedocs project page](https://readthedocs.org/projects/cleanvision/) and `build` latest version.
 If you want to see how a specific branch output looks, activate the branch in `version` tab and then `build` that branch.
+
+
+## Publishing Release
+- Ensure all **Checks** are successful for your PR after getting approvals from other code maintainers.
+- Go to the Releases in the Github repo and draft a new release.
+- Create a new tag in the format `v{version}` corresponding to the version being released and click *Generate  release notes*.
+- Before publishing the release, ensure all checks are satisfied as the release on TestPypi and Pypi is automated and an error will result in publishing a new version.
+- Publish release.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,8 +113,9 @@ The docs for this repo are hosted by readthedocs.io and can be found [here](http
 
 
 ## Publishing Release
-- Ensure all **Checks** are successful for your PR after getting approvals from other code maintainers.
+- Ensure all **Checks** are successful for your release related PR after getting approvals from other code maintainers.
+- Merge all release related PRs.
 - Go to the Releases in the Github repo and draft a new release.
 - Create a new tag in the format `v{version}` corresponding to the version being released and click *Generate  release notes*.
 - Before publishing the release, ensure all checks are satisfied as the release on TestPypi and Pypi is automated and an error will result in publishing a new version.
-- Publish release.
+- Publish release


### PR DESCRIPTION
Added a release pipeline with 3 jobs that will be executed in order:
1. Publish to TestPypi
2. Publish to Pypi
3. Bump patch version of the package and commit

This workflow will be triggered whenever the `CI` workflow is triggered in `main` branch **or** a release is published. However for the action of uploading the package to TestPypi and Pypi, `CI` workflow should be successful on `main` branch **and** release should be published.