### PR TITLE
make package pep561 compatible.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include CONTRIBUTING.md DEVELOPMENT.md CODE_OF_CONDUCT.md
+include CONTRIBUTING.md DEVELOPMENT.md CODE_OF_CONDUCT.md src/cleanvision/py.typed


### PR DESCRIPTION
Hi,
Thank you for the great work.

this MR makes the package pep561 conformant. 

If I run this script:
```python
import cleanvision 

def test(s: str = ""):
   print(s)

if __name__ == "__main__":
   test("1")

```

Before:
```
mypy *.py
main.py:1: error: Skipping analyzing "cleanvision": module is installed, but missing library stubs or py.typed marker  [import]
main.py:1: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 1 source file)

```

After
```
mypy *.py
Success: no issues found in 1 source file
```

Excellent [blog post](https://jugmac00.github.io/blog/bite-my-shiny-type-annotated-library/) of what needed to be done

He mentions we need to set include_package_data=True. But [setuptools](https://setuptools.pypa.io/en/latest/userguide/datafiles.html) with pyproject.toml does this by default.
```
[tool.setuptools]
# ...
# By default, include-package-data is true in pyproject.toml, so you do
# NOT have to specify this line.
include-package-data = true
```
So it should work for sdist and weels as well now. 