### PR TITLE
Updated threshold for dark issue

### DIFF
--- a/src/cleanvision/issue_managers/image_property_issue_manager.py
+++ b/src/cleanvision/issue_managers/image_property_issue_manager.py
@@ -59,7 +59,7 @@ class ImagePropertyIssueManager(IssueManager):
 
     def get_default_params(self) -> Dict[str, Any]:
         return {
-            IssueType.DARK.value: {"threshold": 0.37},
+            IssueType.DARK.value: {"threshold": 0.32},
             IssueType.LIGHT.value: {"threshold": 0.05},
             IssueType.ODD_ASPECT_RATIO.value: {"threshold": 0.35},
             IssueType.LOW_INFORMATION.value: {


### PR DESCRIPTION
Updated threshold from 0.37 to 0.32
Borderline images from various datasets that are eliminated
![Screenshot 2023-05-16 at 4 37 51 PM](https://github.com/cleanlab/cleanvision/assets/7639432/2e0d1f6d-9326-46a6-b4bc-93e5b13524ab)
![Screenshot 2023-05-16 at 4 38 22 PM](https://github.com/cleanlab/cleanvision/assets/7639432/2c38a554-478f-41b0-9cb7-843fb6fb46fc)
![Screenshot 2023-05-16 at 4 38 46 PM](https://github.com/cleanlab/cleanvision/assets/7639432/7f1415a4-447b-4438-83cd-b246387c6e59)
![Screenshot 2023-05-16 at 4 39 25 PM](https://github.com/cleanlab/cleanvision/assets/7639432/057ecbba-7b87-462d-b2fe-0ddee0f75978)
![Screenshot 2023-05-16 at 4 39 46 PM](https://github.com/cleanlab/cleanvision/assets/7639432/3801b97c-7c52-4179-96d4-9e7f3858125b)
![Screenshot 2023-05-16 at 4 40 26 PM](https://github.com/cleanlab/cleanvision/assets/7639432/0f38645b-756c-4e6f-9ebb-00c4d0ff21cd)
