### PR TITLE
Blurry

### DIFF
--- a/src/cleanvision/imagelab.py
+++ b/src/cleanvision/imagelab.py
@@ -529,6 +529,7 @@ class Imagelab:
     def visualize(
         self,
         image_files: Optional[List[str]] = None,
+        indices: Optional[List[str | int]] = None,
         issue_types: Optional[List[str]] = None,
         num_images: int = 4,
         cell_size: Tuple[int, int] = (2, 2),
@@ -600,6 +601,15 @@ class Imagelab:
                 raise ValueError("image_files list is empty.")
             images = [Image.open(path) for path in image_files]
             titles = [path.split("/")[-1] for path in image_files]
+            VizManager.individual_images(
+                images,
+                titles,
+                ncols=self._config["visualize_num_images_per_row"],
+                cell_size=cell_size,
+            )
+        elif indices:
+            images = [self._dataset[i] for i in indices]
+            titles = [self._dataset.get_name(i) for i in indices]
             VizManager.individual_images(
                 images,
                 titles,

--- a/src/cleanvision/imagelab.py
+++ b/src/cleanvision/imagelab.py
@@ -526,6 +526,7 @@ class Imagelab:
                     cell_size=cell_size,
                 )
 
+    # todo: compress this code
     def visualize(
         self,
         image_files: Optional[List[str]] = None,
@@ -548,6 +549,12 @@ class Imagelab:
 
         image_files : List[str], optional
             List of filepaths for images to visualize.
+
+        indices: List[str|int], optional
+            List of indices of images in the dataset to visualize.
+            If the dataset is a local data_path, the indices are filepaths, which is also the index in `imagelab.issues` dataframe.
+            If the dataset is a huggingface or torchvision dataset, indices are of type int and corresponding to the indices in the dataset object.
+
 
         issue_types: List[str], optional
             List of issue types to visualize. For each type of issue, will show a few images representing the top-most severe instances of this issue in the dataset.

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -246,7 +246,7 @@ class BlurrinessProperty(ImageProperty):
         return self._score_columns
 
     def __init__(self) -> None:
-        self._score_columns = [self.name, "grayscale_std"]
+        self._score_columns = [self.name, "blurriness_grayscale_std"]
         self.max_resolution = MAX_RESOLUTION_FOR_BLURRY_DETECTION
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
@@ -257,7 +257,7 @@ class BlurrinessProperty(ImageProperty):
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),
-            "grayscale_std": calc_std_grayscale(gray_image),
+            "blurriness_grayscale_std": calc_std_grayscale(gray_image),
         }
 
     def get_scores(
@@ -269,7 +269,9 @@ class BlurrinessProperty(ImageProperty):
     ) -> pd.DataFrame:
         super().get_scores(raw_scores, issue_type, **kwargs)
         blur_scores = 1 - np.exp(-1 * raw_scores[self.name] * normalizing_factor)
-        std_scores = 1 - np.exp(-1 * raw_scores["grayscale_std"] * normalizing_factor)
+        std_scores = 1 - np.exp(
+            -1 * raw_scores["blurriness_grayscale_std"] * normalizing_factor
+        )
         std_scores[std_scores <= 0.18] = 0
 
         scores = pd.DataFrame(index=raw_scores.index)

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -250,13 +250,13 @@ class BlurrinessProperty(ImageProperty):
         self.max_resolution = MAX_RESOLUTION_FOR_BLURRY_DETECTION
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
-        # if max(image.width, image.height) > self.max_resolution:
-        #     ratio = max(image.width, image.height) / self.max_resolution
-        #     resized_image = image.resize(
-        #         (int(image.width // ratio), int(image.height // ratio))
-        #     )
-        # else:
-        resized_image = image.copy()
+        if max(image.width, image.height) > self.max_resolution:
+            ratio = max(image.width, image.height) / self.max_resolution
+            resized_image = image.resize(
+                (int(image.width // ratio), int(image.height // ratio))
+            )
+        else:
+            resized_image = image.copy()
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -276,7 +276,7 @@ class BlurrinessProperty(ImageProperty):
         std_scores = 1 - np.exp(
             -1 * raw_scores["blurriness_grayscale_std"] * normalizing_factor
         )
-        std_scores[std_scores <= color_threshold] = 0
+        std_scores[std_scores <= 0.18] = 0
 
         scores = pd.DataFrame(index=raw_scores.index)
         scores[get_score_colname(issue_type)] = np.minimum(blur_scores + std_scores, 1)

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -231,11 +231,11 @@ class EntropyProperty(ImageProperty):
 def calc_blurriness(gray_image: Image) -> float:
     edges = get_edges(gray_image)
     blurriness = ImageStat.Stat(edges).var[0]
-    return np.sqrt(blurriness) / (gray_image.width * gray_image.height)  # type:ignore
+    return np.sqrt(blurriness)  # type:ignore
 
 
 def calc_std_grayscale(gray_image: Image):
-    return np.std(gray_image.histogram()) / (gray_image.width * gray_image.height)
+    return np.std(gray_image.histogram())
 
 
 class BlurrinessProperty(ImageProperty):

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -251,9 +251,12 @@ class BlurrinessProperty(ImageProperty):
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
         ratio = max(image.width, image.height) / self.max_resolution
-        resized_image = image.resize(
-            (int(image.width // ratio), int(image.height // ratio))
-        )
+        if ratio > 1:
+            resized_image = image.resize(
+                (int(image.width // ratio), int(image.height // ratio))
+            )
+        else:
+            resized_image = image.copy()
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -250,13 +250,13 @@ class BlurrinessProperty(ImageProperty):
         self.max_resolution = MAX_RESOLUTION_FOR_BLURRY_DETECTION
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
-        if max(image.width, image.height) > self.max_resolution:
-            ratio = max(image.width, image.height) / self.max_resolution
-            resized_image = image.resize(
-                (int(image.width // ratio), int(image.height // ratio))
-            )
-        else:
-            resized_image = image.copy()
+        # if max(image.width, image.height) > self.max_resolution:
+        ratio = max(image.width, image.height) / self.max_resolution
+        resized_image = image.resize(
+            (int(image.width // ratio), int(image.height // ratio))
+        )
+        # else:
+        #     resized_image = image.copy()
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -234,8 +234,8 @@ def calc_blurriness(gray_image: Image) -> float:
     return np.sqrt(blurriness)  # type:ignore
 
 
-def calc_std_grayscale(gray_image: Image):
-    return np.std(gray_image.histogram())
+def calc_std_grayscale(gray_image: Image) -> float:
+    return np.std(gray_image.histogram())  # type: ignore
 
 
 class BlurrinessProperty(ImageProperty):

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -250,13 +250,10 @@ class BlurrinessProperty(ImageProperty):
         self.max_resolution = MAX_RESOLUTION_FOR_BLURRY_DETECTION
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
-        # if max(image.width, image.height) > self.max_resolution:
         ratio = max(image.width, image.height) / self.max_resolution
         resized_image = image.resize(
             (int(image.width // ratio), int(image.height // ratio))
         )
-        # else:
-        #     resized_image = image.copy()
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),
@@ -276,7 +273,7 @@ class BlurrinessProperty(ImageProperty):
         std_scores = 1 - np.exp(
             -1 * raw_scores["blurriness_grayscale_std"] * normalizing_factor
         )
-        std_scores[std_scores <= 0.18] = 0
+        std_scores[std_scores <= color_threshold] = 0
 
         scores = pd.DataFrame(index=raw_scores.index)
         scores[get_score_colname(issue_type)] = np.minimum(blur_scores + std_scores, 1)

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -250,10 +250,13 @@ class BlurrinessProperty(ImageProperty):
         self.max_resolution = MAX_RESOLUTION_FOR_BLURRY_DETECTION
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:
-        ratio = max(image.width, image.height) / MAX_RESOLUTION_FOR_BLURRY_DETECTION
-        resized_image = image.resize(
-            (int(image.width // ratio), int(image.height // ratio))
-        )
+        if max(image.width, image.height) > MAX_RESOLUTION_FOR_BLURRY_DETECTION:
+            ratio = max(image.width, image.height) / MAX_RESOLUTION_FOR_BLURRY_DETECTION
+            resized_image = image.resize(
+                (int(image.width // ratio), int(image.height // ratio))
+            )
+        else:
+            resized_image = image.copy()
         gray_image = resized_image.convert("L")
         return {
             self.name: calc_blurriness(gray_image),

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -230,10 +230,11 @@ class EntropyProperty(ImageProperty):
 
 def calc_blurriness(image: Image, max_resolution: int) -> float:
     ratio = max(image.width, image.height) / max_resolution
-    if ratio > 1:
-        low_rs = image.resize((int(image.width // ratio), int(image.height // ratio)))
-    else:
-        low_rs = image
+    # if ratio > 1:
+    #     low_rs = image.resize((int(image.width // ratio), int(image.height // ratio)))
+    # else:
+    #     low_rs = image
+    low_rs = image.resize((int(image.width // ratio), int(image.height // ratio)))
     edges = get_edges(low_rs)
     blurriness = ImageStat.Stat(edges).var[0]
     assert isinstance(

--- a/src/cleanvision/issue_managers/image_property_issue_manager.py
+++ b/src/cleanvision/issue_managers/image_property_issue_manager.py
@@ -23,7 +23,6 @@ from cleanvision.utils.constants import (
 from cleanvision.utils.utils import (
     get_is_issue_colname,
     update_df,
-    get_score_colname,
 )
 
 
@@ -104,15 +103,6 @@ class ImagePropertyIssueManager(IssueManager):
 
         return defer_set
 
-    def _get_additional_to_compute_set(self, issue_types: List[str]) -> List[str]:
-        additional_set = []
-        if (
-            IssueType.BLURRY.value in issue_types
-            and IssueType.DARK.value not in issue_types
-        ):
-            additional_set.append(IssueType.DARK.value)
-        return additional_set
-
     def find_issues(
         self,
         *,
@@ -130,8 +120,6 @@ class ImagePropertyIssueManager(IssueManager):
 
         self.issue_types = list(params.keys())
         self.issues = pd.DataFrame(index=dataset.index)
-        additional_set = self._get_additional_to_compute_set(self.issue_types)
-        self.issue_types = self.issue_types + additional_set
 
         self.update_params(params)
 
@@ -207,43 +195,6 @@ class ImagePropertyIssueManager(IssueManager):
             score_column_names = self.image_properties[issue_type].score_columns
             score_columns = agg_computations[score_column_names]
 
-            # # todo: this is hacky
-            # # Only blurry issue is dependent on another issue (in this case dark) for computing scores.
-            # # This if else block handles this special case.
-            # if issue_type == IssueType.BLURRY.value:
-            #     # In the case when blurry scores need to be computed
-            #     # dark_score and is_dark_issue can be retrieved from one of these two places
-            #     # 1. self.issues
-            #     # 2. recomputed using brightness_perc_99 info present in agg_computations.
-            #     dark_issue = IssueType.DARK.value
-            #     if not {
-            #         get_is_issue_colname(dark_issue),
-            #         get_score_colname(dark_issue),
-            #     }.issubset(self.issues):
-            #         dark_score_columns = agg_computations[
-            #             self.image_properties[dark_issue].score_columns
-            #         ]
-            #         dark_property = self.image_properties[dark_issue]
-            #
-            #         dark_issue_scores = dark_property.get_scores(
-            #             dark_score_columns, dark_issue, **self.params[dark_issue]
-            #         )
-            #         is_dark_issue = dark_property.mark_issue(
-            #             dark_issue_scores,
-            #             self.params[dark_issue].get("threshold"),
-            #             dark_issue,
-            #         )
-            #     else:
-            #         dark_issue_scores = self.issues[[get_score_colname(dark_issue)]]
-            #         is_dark_issue = self.issues[[get_is_issue_colname(dark_issue)]]
-
-            #     issue_scores = self.image_properties[issue_type].get_scores(
-            #         score_columns,
-            #         issue_type,
-            #         **self.params[issue_type],
-            #         dark_issue_data=dark_issue_scores.join(is_dark_issue),
-            #     )
-            # else:
             issue_scores = self.image_properties[issue_type].get_scores(
                 score_columns, issue_type, **self.params[issue_type]
             )

--- a/src/cleanvision/issue_managers/image_property_issue_manager.py
+++ b/src/cleanvision/issue_managers/image_property_issue_manager.py
@@ -65,7 +65,11 @@ class ImagePropertyIssueManager(IssueManager):
                 "threshold": 0.3,
                 "normalizing_factor": 0.1,
             },
-            IssueType.BLURRY.value: {"threshold": 0.17, "normalizing_factor": 0.01},
+            IssueType.BLURRY.value: {
+                "threshold": 0.29,
+                "normalizing_factor": 0.01,
+                "color_threshold": 0.18,
+            },
             IssueType.GRAYSCALE.value: {},
         }
 

--- a/src/cleanvision/issue_managers/image_property_issue_manager.py
+++ b/src/cleanvision/issue_managers/image_property_issue_manager.py
@@ -207,46 +207,46 @@ class ImagePropertyIssueManager(IssueManager):
             score_column_names = self.image_properties[issue_type].score_columns
             score_columns = agg_computations[score_column_names]
 
-            # todo: this is hacky
-            # Only blurry issue is dependent on another issue (in this case dark) for computing scores.
-            # This if else block handles this special case.
-            if issue_type == IssueType.BLURRY.value:
-                # In the case when blurry scores need to be computed
-                # dark_score and is_dark_issue can be retrieved from one of these two places
-                # 1. self.issues
-                # 2. recomputed using brightness_perc_99 info present in agg_computations.
-                dark_issue = IssueType.DARK.value
-                if not {
-                    get_is_issue_colname(dark_issue),
-                    get_score_colname(dark_issue),
-                }.issubset(self.issues):
-                    dark_score_columns = agg_computations[
-                        self.image_properties[dark_issue].score_columns
-                    ]
-                    dark_property = self.image_properties[dark_issue]
+            # # todo: this is hacky
+            # # Only blurry issue is dependent on another issue (in this case dark) for computing scores.
+            # # This if else block handles this special case.
+            # if issue_type == IssueType.BLURRY.value:
+            #     # In the case when blurry scores need to be computed
+            #     # dark_score and is_dark_issue can be retrieved from one of these two places
+            #     # 1. self.issues
+            #     # 2. recomputed using brightness_perc_99 info present in agg_computations.
+            #     dark_issue = IssueType.DARK.value
+            #     if not {
+            #         get_is_issue_colname(dark_issue),
+            #         get_score_colname(dark_issue),
+            #     }.issubset(self.issues):
+            #         dark_score_columns = agg_computations[
+            #             self.image_properties[dark_issue].score_columns
+            #         ]
+            #         dark_property = self.image_properties[dark_issue]
+            #
+            #         dark_issue_scores = dark_property.get_scores(
+            #             dark_score_columns, dark_issue, **self.params[dark_issue]
+            #         )
+            #         is_dark_issue = dark_property.mark_issue(
+            #             dark_issue_scores,
+            #             self.params[dark_issue].get("threshold"),
+            #             dark_issue,
+            #         )
+            #     else:
+            #         dark_issue_scores = self.issues[[get_score_colname(dark_issue)]]
+            #         is_dark_issue = self.issues[[get_is_issue_colname(dark_issue)]]
 
-                    dark_issue_scores = dark_property.get_scores(
-                        dark_score_columns, dark_issue, **self.params[dark_issue]
-                    )
-                    is_dark_issue = dark_property.mark_issue(
-                        dark_issue_scores,
-                        self.params[dark_issue].get("threshold"),
-                        dark_issue,
-                    )
-                else:
-                    dark_issue_scores = self.issues[[get_score_colname(dark_issue)]]
-                    is_dark_issue = self.issues[[get_is_issue_colname(dark_issue)]]
-
-                issue_scores = self.image_properties[issue_type].get_scores(
-                    score_columns,
-                    issue_type,
-                    **self.params[issue_type],
-                    dark_issue_data=dark_issue_scores.join(is_dark_issue),
-                )
-            else:
-                issue_scores = self.image_properties[issue_type].get_scores(
-                    score_columns, issue_type, **self.params[issue_type]
-                )
+            #     issue_scores = self.image_properties[issue_type].get_scores(
+            #         score_columns,
+            #         issue_type,
+            #         **self.params[issue_type],
+            #         dark_issue_data=dark_issue_scores.join(is_dark_issue),
+            #     )
+            # else:
+            issue_scores = self.image_properties[issue_type].get_scores(
+                score_columns, issue_type, **self.params[issue_type]
+            )
 
             is_issue = self.image_properties[issue_type].mark_issue(
                 issue_scores, self.params[issue_type].get("threshold"), issue_type

--- a/src/cleanvision/utils/constants.py
+++ b/src/cleanvision/utils/constants.py
@@ -15,7 +15,7 @@ SETS: str = "sets"
 
 # max number of processes that can be forked/spawned for multiprocessing
 MAX_PROCS = 5000
-MAX_RESOLUTION_FOR_BLURRY_DETECTION = 64
+MAX_RESOLUTION_FOR_BLURRY_DETECTION = 32
 
 IMAGE_FILE_EXTENSIONS: List[str] = [
     "*.jpg",

--- a/src/cleanvision/utils/constants.py
+++ b/src/cleanvision/utils/constants.py
@@ -15,7 +15,7 @@ SETS: str = "sets"
 
 # max number of processes that can be forked/spawned for multiprocessing
 MAX_PROCS = 5000
-MAX_RESOLUTION_FOR_BLURRY_DETECTION = 256
+MAX_RESOLUTION_FOR_BLURRY_DETECTION = 64
 
 IMAGE_FILE_EXTENSIONS: List[str] = [
     "*.jpg",

--- a/src/cleanvision/utils/constants.py
+++ b/src/cleanvision/utils/constants.py
@@ -15,7 +15,7 @@ SETS: str = "sets"
 
 # max number of processes that can be forked/spawned for multiprocessing
 MAX_PROCS = 5000
-MAX_RESOLUTION_FOR_BLURRY_DETECTION = 32
+MAX_RESOLUTION_FOR_BLURRY_DETECTION = 64
 
 IMAGE_FILE_EXTENSIONS: List[str] = [
     "*.jpg",

--- a/tests/test_image_property_helpers.py
+++ b/tests/test_image_property_helpers.py
@@ -12,7 +12,6 @@ from cleanvision.issue_managers.image_property import (
     calc_aspect_ratio,
     calc_entropy,
     calc_blurriness,
-    get_edges,
 )
 from cleanvision.utils.utils import get_is_issue_colname, get_score_colname
 
@@ -46,11 +45,9 @@ def test_calc_entropy():
 
 
 def test_calc_bluriness():
-    img = Image.new("RGB", (200, 200), (255, 0, 0))
-    edges = get_edges(img)
-    blurriness = calc_blurriness(img, 512)
-    assert isinstance(edges, Image.Image)
-    assert isinstance(blurriness, float)
+    gray_img = Image.new("RGB", (200, 200), (0, 0, 0)).convert("L")
+    blurriness = calc_blurriness(gray_img)
+    assert blurriness == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Updated logic for blurry issue type
   Previous logic avoided FP like objects against black backgrounds by a low blurriness threshold. This also resulted in more FN. The current logic better handles these kinds of images, hence we can include decrease FN by increasing the threshold.
- Added an optional argument `indices` in `Imagelab.visualize()`, found this useful when evaluating huggingface and torchvision datasets.
![Screenshot 2023-05-24 at 11 13 25 AM](https://github.com/cleanlab/cleanvision/assets/7639432/0387d700-37b5-4a25-806f-fbb9e8d96a45)
