### PR TITLE
expand list of supported file formats to consider more cases

### DIFF
--- a/src/cleanvision/utils/constants.py
+++ b/src/cleanvision/utils/constants.py
@@ -21,12 +21,18 @@ MAX_RESOLUTION_FOR_BLURRY_DETECTION = 64
 
 IMAGE_FILE_EXTENSIONS: List[str] = [
     "*.jpg",
+    "*.JPG",
     "*.jpeg",
-    "*.gif",
-    "*.jp2",
-    "*.TIFF",
-    "*.WebP",
-    "*.PNG",
     "*.JPEG",
+    "*.gif",
+    "*.GIF",
+    "*.jp2",
+    "*.JP2",
     "*.png",
+    "*.PNG",
+    "*.tiff",
+    "*.TIFF",
+    "*.webp",
+    "*.WebP",
+    "*.WEBP",
 ]  # filetypes supported by PIL


### PR DESCRIPTION
Quick fix for: https://github.com/cleanlab/cleanvision/issues/197

There is definitely a more intelligent way to do this for a longer term solution.