### PR TITLE
Add ahash, dhash and chash to near_duplicates issue

### DIFF
--- a/docs/source/tutorials/tutorial.ipynb
+++ b/docs/source/tutorials/tutorial.ipynb
@@ -510,7 +510,7 @@
     "\n",
     "`hash_size` - This controls how much detail about an image we want to keep for getting perceptual hash. Higher sizes imply more detail.\n",
     "\n",
-    "`hash_type` - Type of perceptual hash to use. Currently `whash` and `phash` are the supported hash types. Check [here](https://github.com/JohannesBuchner/imagehash) for more details on these hash types.\n",
+    "`hash_type` - Type of perceptual hash to use. Currently `whash`, `phash`, `ahash`, `dhash` and `chash` are the supported hash types. Check [here](https://github.com/JohannesBuchner/imagehash) for more details on these hash types.\n",
     "\n",
     "|   | Issue Key        | Hyperparameters                                   |\n",
     "|---|------------------|---------------------------------------------------|\n",
@@ -518,7 +518,7 @@
     "| 2 | dark             | threshold (between 0 and 1)                       |\n",
     "| 3 | odd_aspect_ratio | threshold (between 0 and 1)                       |\n",
     "| 4 | exact_duplicates | N/A                                               |\n",
-    "| 5 | near_duplicates  | hash_size (power of 2), hash_types (whash, phash) |\n",
+    "| 5 | near_duplicates  | hash_size (int, only power of 2 for whash), hash_types (whash, phash, ahash, dhash, chash) |\n",
     "| 6 | blurry           | threshold (between 0 and 1)                       |\n",
     "| 7 | grayscale        | threshold (between 0 and 1)                       |\n",
     "| 8 | low_information  | threshold (between 0 and 1)                       |"

--- a/src/cleanvision/issue_managers/duplicate_issue_manager.py
+++ b/src/cleanvision/issue_managers/duplicate_issue_manager.py
@@ -24,6 +24,12 @@ def get_hash(image: Image.Image, params: Dict[str, Any]) -> str:
         return str(imagehash.whash(image, hash_size=hash_size))
     elif hash_type == "phash":
         return str(imagehash.phash(image, hash_size=hash_size))
+    elif hash_type == "ahash":
+        return str(imagehash.average_hash(image, hash_size=hash_size))
+    elif hash_type == "dhash":
+        return str(imagehash.dhash(image, hash_size=hash_size))
+    elif hash_type == "chash":
+        return str(imagehash.colorhash(image, binbits=hash_size))
     else:
         raise ValueError("Hash type not supported")
 

--- a/tests/test_duplicate_issue_manager.py
+++ b/tests/test_duplicate_issue_manager.py
@@ -248,6 +248,15 @@ def test_get_hash():
     hash = get_hash(img, {"hash_type": "phash", "hash_size": 2})
     assert hash is not None
 
+    hash = get_hash(img, {"hash_type": "ahash", "hash_size": 2})
+    assert hash is not None
+
+    hash = get_hash(img, {"hash_type": "dhash", "hash_size": 2})
+    assert hash is not None
+
+    hash = get_hash(img, {"hash_type": "chash", "hash_size": 2})
+    assert hash is not None
+
     # Test calling function with not a real hash
     with pytest.raises(ValueError, match="not supported"):
         get_hash(img, {"hash_type": "fake_hash"})


### PR DESCRIPTION
Add more hash types supported by imagehash for user to evaluate across multiple image comparing methods
