### PR TITLE
Simple Clean up, .gitignore improved, PR template added

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,41 +1,81 @@
 ## Summary
 
-> What is the reason for this Pull-Request? If adding new functionality, please comment:
-> a code snippet showcasing the end-to-end usage of your new methods, and the exact output
-> from this code (print out any returned variables).
+> 🎯 **Purpose**: Describe the objective of your changes in this Pull-Request.
+>
+> 📜 **Example Usage**: If adding new functionality, strive to provide a minimal working example (MWE) that demonstrates end-to-end usage and output of your new methods. If creating a MWE is not feasible, a conceptual code snippet showcasing the usage is also appreciated. Ensure that the code provided can be copied, pasted, and run without modifications.
 
+**[ ✏️ Write your summary here. ]**
 
+```python
+# Example code snippet
+
+# Necessary Imports:
+from my_module import my_new_function
+
+# Setup if needed (e.g., data loading, model instantiation):
+a = 20
+b = 22
+
+# Usage and Output:
+result = my_new_function(a, b)
+# 42
+
+# ---- Your code below ----
+# [Replace the example above with your own code, ensuring it is executable and demonstrates your feature or fix.]
+[your_uncommented_runnable_code_here]
+# [your_output_here_as_a_comment]
+```
 
 ## Impact
 
-> What is the scope of your changes and who/where do you think they will affect?
-> If your change modifies documentation or a tutorial notebook, please include
-> screenshots showing the rendered outputs for a quicker initial review.
+> 🌐 Areas Affected: Enumerate modules, functions, or documentation impacted by your code.
+>
+> 👥 Who’s Affected: Mention who might be impacted (if applicable).
 
+**Screenshots**
+
+> 📸 If your changes modify documentation or a tutorial notebook, please include screenshots or GIFs showing the rendered outputs for a quicker initial review, highlighting the main changes.
 
 
 ## Testing
 
-> What testing have you done and verified? Please link to the one unit test
-> that is most end-to-end check of your new functionality. It's ok if your
-> unit tests are not yet comprehensive when you first open the PR,
+> 🔍 Testing Done: Outline what kinds of tests you performed.
+>
+> 🔗 Test Case Link: Directly link to the most end-to-end check of your new functionality.
+
+**Unaddressed Cases**
+
+> It's ok if your unit tests are not yet
+> comprehensive when you first open the PR,
 > we can revisit them later!
+>
+> ⚠️ Mention any aspects of testing that have *not* been covered, and why.
 
 -
 
-## Ticket(s) or Conversations
+## Links to Relevant Issues or Conversations
 
-> What Git or Slack items (Issues, threads, etc) that are specifically related to
+> 🔗 What Git or Slack items (Issues, threads, etc) that are specifically related to
 > this work? Please link them here.
 
 -
 
 ## References
 
-> Include any extra information that may be helpful to reviewers of your
+> 📚 Include any extra information that may be helpful to reviewers of your
 > Pull-Request here (e.g. relevant URLs or Wiki pages that could help give
-> background information). If relevant, please include additional code snippets
-> (and their outputs/return values) showing alternative ways to use your newly
-> added methods.
+> background information).
+>
+> Share links, docs, or sources that facilitated your changes.
+>
+> If relevant, please include additional code snippets
+> (and their outputs/return values) showing alternative ways to use your newly added methods.
+
+```python
+[additional code snippets and explanations]
+```
 
 -
+
+## Reviewer Notes
+> 💡 Include any specific points for the reviewer to consider during their review.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 ## Summary
 
-> What is the reason for this Pull-Request?
+> What is the reason for this Pull-Request? If adding new functionality, please comment:
+> a code snippet showcasing the end-to-end usage of your new methods, and the exact output
+> from this code (print out any returned variables).
 
 
 
@@ -12,17 +14,26 @@
 
 ## Testing
 
-> What testing have you done and verified? Please link to the one unit test that is most end-to-end check of your new functionality. It's ok if your unit tests are not yet comprehensive when you first open the PR, we can revisit them later!  
+> What testing have you done and verified? Please link to the one unit test
+> that is most end-to-end check of your new functionality. It's ok if your
+> unit tests are not yet comprehensive when you first open the PR,
+> we can revisit them later!
 
 -
 
 ## Ticket(s) or Conversations
 
-> What Git or Slack items (Issues, threads etc) are specifically related to this work? Please link them here.
+> What Git or Slack items (Issues, threads, etc) that are specifically related to
+> this work? Please link them here.
 
+-
 
 ## References
 
-> Include any extra information that may be helpful to reviewers of your Pull-Request here (e.g. relevant URLs or Wiki pages that could help give background information). If relevant, please include additional code snippets (and their outputs/return values) showing alternative ways to use your newly added methods.
+> Include any extra information that may be helpful to reviewers of your
+> Pull-Request here (e.g. relevant URLs or Wiki pages that could help give
+> background information). If relevant, please include additional code snippets
+> (and their outputs/return values) showing alternative ways to use your newly
+> added methods.
 
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Summary
 
-> What is the reason for this Pull-Request? Are you bumping the version?
+> What is the reason for this Pull-Request?
 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+> What is the reason for this Pull-Request? Are you bumping the version?
+
+
+
+## Impact
+
+> What is the scope of your changes and who/where do you think they will affect?
+
+
+
+## Testing
+
+> What testing have you done and verified? If you can't test, please say why that is.
+
+-
+
+## Ticket(s) or Conversations
+
+> What Git or Slack items (Issues, threads etc) are specifically related to this work? Please link them here.
+
+
+## References
+
+> Do you have any relevant URLs or Wiki pages that could help give background information for the changes in this Pull-Request? These are usually StackOverflow posts, Notion wiki pages, Wikipedia articles, or links to APIs and Documentation of third-party packages.
+
+-

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,6 @@
 
 ## References
 
-> Do you have any relevant URLs or Wiki pages that could help give background information for the changes in this Pull-Request? These are usually StackOverflow posts, Notion wiki pages, Wikipedia articles, or links to APIs and Documentation of third-party packages.
+> Include any extra information that may be helpful to reviewers of your Pull-Request here (e.g. relevant URLs or Wiki pages that could help give background information). If relevant, please include additional code snippets (and their outputs/return values) showing alternative ways to use your newly added methods.
 
 -

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@
 ## Impact
 
 > What is the scope of your changes and who/where do you think they will affect?
+> If your change modifies documentation or a tutorial notebook, please include
+> screenshots showing the rendered outputs for a quicker initial review.
 
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@
 
 ## Testing
 
-> What testing have you done and verified? If you can't test, please say why that is.
+> What testing have you done and verified? Please link to the one unit test that is most end-to-end check of your new functionality. It's ok if your unit tests are not yet comprehensive when you first open the PR, we can revisit them later!  
 
 -
 

--- a/.gitignore
+++ b/.gitignore
@@ -24,19 +24,29 @@ cifar*
 # Byte-compiled / optimized / DLL files
 *.py[cod]
 *$py.class
-.direnv
+
+# development environment configuration files
 .idea
 .idea/**
 .vscode
 .vscode/**
+
+# Python Environments
+.direnv
+.env
+.venv
+env/
+venv/
+env.bak/
+venv.bak/
 
 # C extensions
 *.so
 
 # Distribution / packaging
 .Python
-develop-eggs/
-downloads/
+develop-eggs/**
+downloads/**
 eggs/
 .eggs/
 lib/
@@ -49,13 +59,6 @@ pip-wheel-metadata/
 share/python-wheels/
 .installed.cfg
 *.egg
-MANIFEST
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
 
 # Installer logs
 pip-log.txt
@@ -63,83 +66,38 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
-.nox/
 .coverage*
 .cache
-nosetests.xml
 *.cover
 *.py,cover
-.hypothesis/
-.pytest_cache/
+.hypothesis/**
+.pytest_cache/**
 
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
+# log files
 *.log
-local_settings.py
-db.sqlite3
-db.sqlite3-journal
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-docs/_build/
-
-# PyBuilder
-target/
+logs/**
 
 # IPython
 profile_default/
 ipython_config.py
-
 __pypackages__/
-
-# Celery stuff
-celerybeat-schedule
-celerybeat.pid
-
-# SageMath parsed files
-*.sage.py
-
-# Environments
-.env
-.venv
-env/
-venv/
-ENV/
-env.bak/
-venv.bak/
-
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
 
 # mkdocs documentation
 /site
 
-# mypy
+# mypy cache
 .mypy_cache/
 .dmypy.json
-dmypy.json
-
-# Pyre type checker
-.pyre/
 
 # Data files
 **.zip
 **-ubyte
 **.gz
+**.tar
+**.7Z
+**.BZ2
+**.rar
 
-outputs/*
+# other files
+outputs/**
 wandb/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,52 +1,18 @@
+# editor/OS cache files
+.idea/
 .DS_Store
-__pycache__/
 .vscode/
+**/.DS_Store
 
 # jupyter notebooks
 .ipynb_checkpoints/
 
-# packaging
-dist/
-*.egg-info/
-build/
-
-# Coverage
-.coverage
-coverage.xml
-
-# Misc
-results/
-image_files*
-
-# datasets
-cifar*
-
-# Byte-compiled / optimized / DLL files
-*.py[cod]
-*$py.class
-
-# development environment configuration files
-.idea
-.idea/**
-.vscode
-.vscode/**
-
-# Python Environments
-.direnv
-.env
-.venv
-env/
-venv/
-env.bak/
-venv.bak/
-
-# C extensions
-*.so
-
 # Distribution / packaging
 .Python
-develop-eggs/**
-downloads/**
+build/
+develop-eggs/
+dist/
+downloads/
 eggs/
 .eggs/
 lib/
@@ -55,39 +21,131 @@ parts/
 sdist/
 var/
 wheels/
-pip-wheel-metadata/
-share/python-wheels/
+*.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+.coverage*
+*.py,cover
+.hypothesis/**
+.pytest_cache/**
+
+# Misc
+results/
+image_files*
+
+# datasets
+cifar*
+
+cleanlab/*.ipynb
+tests/fasttext_data/
+data/
+docs/_build/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt
 
-# Unit test / coverage reports
-htmlcov/
-.coverage*
-.cache
-*.cover
-*.py,cover
-.hypothesis/**
-.pytest_cache/**
+# Translations
+*.mo
+*.pot
 
-# log files
+# Django stuff:
 *.log
-logs/**
+local_settings.py
+db.sqlite3
+logs/
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+build
+_build
+cleanlab-docs
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+.direnv
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# Downloaded datasets for docs
+/docs/source/notebooks/aclImdb
+/docs/source/notebooks/data
+/docs/source/notebooks/*.gz
+/docs/source/notebooks/spoken_digits
+/docs/source/notebooks/pretrained_models
+/docs/source/tutorials/datalab/datalab-files/
 
 # IPython
 profile_default/
 ipython_config.py
 __pypackages__/
 
-# mkdocs documentation
-/site
-
-# mypy cache
-.mypy_cache/
-.dmypy.json
 
 # Data files
 **.zip
@@ -98,6 +156,3 @@ __pypackages__/
 **.BZ2
 **.rar
 
-# other files
-outputs/**
-wandb/**

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ image_files*
 # datasets
 cifar*
 
-cleanlab/*.ipynb
 tests/fasttext_data/
 data/
 docs/_build/

--- a/.gitignore
+++ b/.gitignore
@@ -8,39 +8,13 @@
 .ipynb_checkpoints/
 
 # Distribution / packaging
-.Python
 build/
-develop-eggs/
 dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
 *.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
 
 # Unit test / coverage reports
-htmlcov/
-.tox/
 .coverage
-.coverage.*
-.cache
-nosetests.xml
 coverage.xml
-*.cover
-.hypothesis/
-.pytest_cache/
-.coverage*
-*.py,cover
-.hypothesis/**
-.pytest_cache/**
 
 # Misc
 results/
@@ -49,60 +23,11 @@ image_files*
 # datasets
 cifar*
 
-data/
-docs/_build/
-
 # Byte-compiled / optimized / DLL files
 __pycache__/
-*.py[cod]
-*$py.class
-
-# C extensions
-*.so
-
-
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-# Translations
-*.mo
-*.pot
-
-# Django stuff:
-*.log
-local_settings.py
-db.sqlite3
-logs/
-
-# Flask stuff:
-instance/
-.webassets-cache
-
-# Scrapy stuff:
-.scrapy
-
-# Sphinx documentation
-build
-_build
-
-# PyBuilder
-target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
-
-# pyenv
-
-
-# SageMath parsed files
-*.sage.py
 
 # Environments
 .env
@@ -114,27 +39,6 @@ env.bak/
 venv.bak/
 .direnv
 
-# Spyder project settings
-.spyderproject
-.spyproject
-
-# Rope project settings
-.ropeproject
-
-# mkdocs documentation
-/site
-
-# mypy
-.mypy_cache/
-
-# Downloaded datasets for docs
-
-# IPython
-profile_default/
-ipython_config.py
-__pypackages__/
-
-
 # Data files
 **.zip
 **-ubyte
@@ -143,4 +47,3 @@ __pypackages__/
 **.7Z
 **.BZ2
 **.rar
-

--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,6 @@ image_files*
 # datasets
 cifar*
 
-tests/fasttext_data/
 data/
 docs/_build/
 
@@ -92,7 +91,6 @@ instance/
 # Sphinx documentation
 build
 _build
-cleanlab-docs
 
 # PyBuilder
 target/
@@ -101,10 +99,7 @@ target/
 .ipynb_checkpoints
 
 # pyenv
-.python-version
 
-# celery beat schedule file
-celerybeat-schedule
 
 # SageMath parsed files
 *.sage.py
@@ -133,12 +128,6 @@ venv.bak/
 .mypy_cache/
 
 # Downloaded datasets for docs
-/docs/source/notebooks/aclImdb
-/docs/source/notebooks/data
-/docs/source/notebooks/*.gz
-/docs/source/notebooks/spoken_digits
-/docs/source/notebooks/pretrained_models
-/docs/source/tutorials/datalab/datalab-files/
 
 # IPython
 profile_default/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.idea/
 .DS_Store
 __pycache__/
 .vscode/
@@ -21,3 +20,135 @@ image_files*
 
 # datasets
 cifar*
+
+# Byte-compiled / optimized / DLL files
+*.py[cod]
+*$py.class
+.direnv
+.idea
+.idea/**
+.vscode
+.vscode/**
+
+# C extensions
+*.so
+**.txt
+
+# Distribution / packaging
+.Python
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage*
+.cache
+nosetests.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython
+profile_default/
+ipython_config.py
+
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Data files
+**/*.json
+*.csv
+**.zip
+**-ubyte
+**.gz
+
+outputs/*
+**.pth
+**.pt
+_data/**
+_model/**
+wandb/**
+
+ENV/**

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ cifar*
 
 # C extensions
 *.so
-**.txt
 
 # Distribution / packaging
 .Python
@@ -138,17 +137,9 @@ dmypy.json
 .pyre/
 
 # Data files
-**/*.json
-*.csv
 **.zip
 **-ubyte
 **.gz
 
 outputs/*
-**.pth
-**.pt
-_data/**
-_model/**
 wandb/**
-
-ENV/**


### PR DESCRIPTION
## Summary

> What is the reason for this Pull-Request? 

This PR improves the .gitignore as well as adds a PR template to be filled in any PR created. 

Added the following sections: 
- Byte-compiled / optimized / DLL files
- development environment configuration files (`.idea, .vscode`)
- Python Virtual Environments (common ones: venv, env, .direnv etc)
- C/c++ extensions (.so)
- Distribution / packaging (.egg, lib, lib64, wheels etc)
- Installer logs
- Unit test / coverage reports
- log files
- IPython (e.g. profile_default/)
- mkdocs documentation
- mypy caches
- compressed files (zip, gz, tar, 7z etc)
- other files (output, wandb)

## Impact

> What is the scope of your changes and who/where do you think they will affect?

- improved gitignore
- new template

## Testing

> What testing have you done and verified? If you can't test, please say why that is.

- I have tested both locally
- I am using the template now

## Ticket(s) or Conversations

> What Git or Slack items (Issues, threads etc) are specifically related to this work? Please link them here.

-N/A

## References

> Do you have any relevant URLs or Wiki pages that could help give background information for the changes in this Pull-Request? These are usually StackOverflow posts, Notion wiki pages, Wikipedia articles, or links to APIs and Documentation of third-party packages.

-
