### PR TITLE
Raise an exception on receiving duplicate filepaths

### DIFF
--- a/src/cleanvision/dataset/fsspec_dataset.py
+++ b/src/cleanvision/dataset/fsspec_dataset.py
@@ -35,6 +35,10 @@ class FSDataset(Dataset):
             self._filepaths = self.__get_filepaths(dataset_path)
         else:
             assert filepaths is not None
+            if len(filepaths) != len(set(filepaths)):
+                raise ValueError(
+                    "Duplicate paths found in the list, please remove duplicate filepaths from the list."
+                )
             self._filepaths = filepaths
             # here we assume all of the provided filepaths are from the same filesystem
             self.fs, _ = fsspec.core.url_to_fs(self._filepaths[0], **self.storage_opts)

--- a/src/cleanvision/dataset/fsspec_dataset.py
+++ b/src/cleanvision/dataset/fsspec_dataset.py
@@ -37,7 +37,7 @@ class FSDataset(Dataset):
             assert filepaths is not None
             if len(filepaths) != len(set(filepaths)):
                 raise ValueError(
-                    "Duplicate paths found in the list, please remove duplicate filepaths from the list."
+                    "Duplicate filepaths found in the provided list, please remove these duplicates."
                 )
             self._filepaths = filepaths
             # here we assume all of the provided filepaths are from the same filesystem

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -179,7 +179,7 @@ def test_run_imagelab_given_filepaths(generate_local_dataset, images_per_class):
 
 def test_raise_error_given_duplicate_filepaths():
     filepaths = ["/home/user/file0.jpg", "/home/user/file1.jpg", "/home/user/file0.jpg"]
-    with pytest.raises(ValueError, match="Duplicate paths found in the list"):
+    with pytest.raises(ValueError, match="Duplicate"):
         Imagelab(filepaths=filepaths)
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -177,6 +177,12 @@ def test_run_imagelab_given_filepaths(generate_local_dataset, images_per_class):
     assert len(imagelab.issues) == images_per_class
 
 
+def test_raise_error_given_duplicate_filepaths():
+    filepaths = ["/home/user/file0.jpg", "/home/user/file1.jpg", "/home/user/file0.jpg"]
+    with pytest.raises(ValueError, match="Duplicate paths found in the list"):
+        Imagelab(filepaths=filepaths)
+
+
 def test_s3_dataset(capsys, get_example_s3_filepaths):
     imagelab = Imagelab(filepaths=get_example_s3_filepaths, storage_opts={"anon": True})
     imagelab.find_issues(


### PR DESCRIPTION
Duplicate filepaths caused out of memory error when doing joins and merges in pandas dataframes.