### PR TITLE
Run CI pipeline on a cron schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ main ]
   pull_request:
+  schedule:
+    - cron: '0 12 * * 1'
 jobs:
   test:
     name: "Test: Python ${{ matrix.python }} on ${{ matrix.os }}"


### PR DESCRIPTION
Added a cron schedule similar to `cleanlab` package for running CI pipeline and detecting any breaks.

Blocked on : https://github.com/cleanlab/cleanvision/pull/249