### PR TITLE
HF datasets version fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: psf/black@stable
+        with:
+          options: "--check -t py37 -t py38 -t py39 -t py310 -t py311"
   pylint:
     name: Lint with flake8 for syntax+other error codes
     runs-on: ubuntu-latest
@@ -60,11 +62,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Install flake8
-        run: pip install flake8
+        run: pip install flake8==7.0.0
       - name: Lint with flake8
-        run: flake8 --ignore=E203,E501,E722,E401,W503 src tests --count --show-source --statistics
+        run: flake8 --ignore=E203,E501,E722,E401,W503,E704 src tests --count --show-source --statistics
   nblint:
     name: Lint Notebooks
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check -t py37 -t py38 -t py39 -t py310 -t py311"
+          jupyter: true
   pylint:
     name: Lint with flake8 for syntax+other error codes
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.1.1
     hooks:
       - id: black
+        language_version: python3.11
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.1
@@ -11,8 +12,8 @@ repos:
         description: Clears output and some metadata from notebooks
 
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.0.0
     hooks:
       - id: flake8
-        args: ['--ignore=E203,E501,E722,E401,W503 src tests --count --show-source --statistics']
+        args: ['--ignore=E203,E501,E722,E401,W503,E704 src tests --count --show-source --statistics']
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ repos:
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1
     hooks:
-      - id: black
+      - id: black-jupyter
         language_version: python3.11
 
   - repo: https://github.com/kynan/nbstripout

--- a/docs/source/tutorials/huggingface_dataset.ipynb
+++ b/docs/source/tutorials/huggingface_dataset.ipynb
@@ -200,7 +200,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indices = imagelab.issues.query('is_blurry_issue').sort_values(by='blurry_score').index.tolist()"
+    "indices = (\n",
+    "    imagelab.issues.query(\"is_blurry_issue\")\n",
+    "    .sort_values(by=\"blurry_score\")\n",
+    "    .index.tolist()\n",
+    ")"
    ]
   },
   {
@@ -216,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset[indices[8]]['image']"
+    "dataset[indices[8]][\"image\"]"
    ]
   },
   {

--- a/docs/source/tutorials/torchvision_dataset.ipynb
+++ b/docs/source/tutorials/torchvision_dataset.ipynb
@@ -218,7 +218,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "indices = imagelab.issues.query('is_dark_issue').sort_values(by='dark_score').index.tolist()"
+    "indices = (\n",
+    "    imagelab.issues.query(\"is_dark_issue\").sort_values(by=\"dark_score\").index.tolist()\n",
+    ")"
    ]
   },
   {

--- a/docs/source/tutorials/tutorial.ipynb
+++ b/docs/source/tutorials/tutorial.ipynb
@@ -212,7 +212,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blurry_images = imagelab.issues[imagelab.issues[\"is_blurry_issue\"] == True].sort_values(by=['blurry_score'])\n",
+    "blurry_images = imagelab.issues[imagelab.issues[\"is_blurry_issue\"] == True].sort_values(\n",
+    "    by=[\"blurry_score\"]\n",
+    ")\n",
     "blurry_image_files = blurry_images.index.tolist()"
    ]
   },
@@ -249,7 +251,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imagelab.visualize(issue_types=['blurry'])"
+    "imagelab.visualize(issue_types=[\"blurry\"])"
    ]
   },
   {
@@ -289,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imagelab.info['statistics'].keys()"
+    "imagelab.info[\"statistics\"].keys()"
    ]
   },
   {
@@ -308,7 +310,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imagelab.info['statistics']['entropy']"
+    "imagelab.info[\"statistics\"][\"entropy\"]"
    ]
   },
   {
@@ -334,7 +336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imagelab.info['exact_duplicates']['num_sets']"
+    "imagelab.info[\"exact_duplicates\"][\"num_sets\"]"
    ]
   },
   {
@@ -351,7 +353,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "imagelab.info['exact_duplicates']['sets']"
+    "imagelab.info[\"exact_duplicates\"][\"sets\"]"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-huggingface = ["datasets>=2.7.0"]
+huggingface = ['datasets>=2.15.0; python_version > "3.7"', 'datasets>=2.7.0; python_version < "3.8"']
 pytorch = ["torchvision>=0.12.0"]
 azure = ["adlfs>=2022.2.0"] # latest compatible with Python 3.7
 gcs = ["gcsfs>=2022.1.0"] # latest compatible with Python 3.7

--- a/src/cleanvision/imagelab.py
+++ b/src/cleanvision/imagelab.py
@@ -3,6 +3,7 @@ Imagelab is the core class in CleanVision for finding all types of issues in an 
 The methods in this module should suffice for most use-cases,
 but advanced users can get extra flexibility via the code in other CleanVision modules.
 """
+
 from __future__ import annotations
 
 import random

--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -73,8 +73,7 @@ def calc_avg_brightness(image: Image) -> float:
 
 
 @overload
-def calculate_brightness(red: float, green: float, blue: float) -> float:
-    ...
+def calculate_brightness(red: float, green: float, blue: float) -> float: ...
 
 
 @overload
@@ -82,8 +81,7 @@ def calculate_brightness(
     red: "np.ndarray[Any, Any]",
     green: "np.ndarray[Any, Any]",
     blue: "np.ndarray[Any, Any]",
-) -> "np.ndarray[Any, Any]":
-    ...
+) -> "np.ndarray[Any, Any]": ...
 
 
 def calculate_brightness(
@@ -127,9 +125,11 @@ class BrightnessProperty(ImageProperty):
     def __init__(self, issue_type: str) -> None:
         self.issue_type = issue_type
         self._score_columns = [
-            "brightness_perc_99"
-            if self.issue_type == IssueType.DARK.value
-            else "brightness_perc_5"
+            (
+                "brightness_perc_99"
+                if self.issue_type == IssueType.DARK.value
+                else "brightness_perc_5"
+            )
         ]
 
     def calculate(self, image: Image) -> Dict[str, Union[float, str]]:


### PR DESCRIPTION
CI fixes:
- Install different versions of datasets for different python versions. Can't use same version as datasets dropped support for python3.7 in version 2.14.0 and it breaks tests using datasets library.
- Use black formatting for jupyter notebooks as well
- Update versions of black and flake8 precommit hooks
- Ignore flake8 error E704 as it is conflicting with black formatting
- Add target versions for black in CI pipeline and only use `check` option and not modify the files.