### PR TITLE
Added a min size of 1 to avoid zero width/length in resize

### DIFF
--- a/src/cleanvision/issue_managers/image_property.py
+++ b/src/cleanvision/issue_managers/image_property.py
@@ -254,7 +254,7 @@ class BlurrinessProperty(ImageProperty):
         ratio = max(image.width, image.height) / self.max_resolution
         if ratio > 1:
             resized_image = image.resize(
-                (int(image.width // ratio), int(image.height // ratio))
+                (max(int(image.width // ratio), 1), max(int(image.height // ratio), 1))
             )
         else:
             resized_image = image.copy()


### PR DESCRIPTION
Avoids zero division in Image.resize() call of blurry check. This is caused by extreme odd aspect ratios present in the dataset. Assigned a min value of 1 to width/height if they are less than 1.